### PR TITLE
First Run Path for Jerni-3

### DIFF
--- a/packages/integrations/tests/e2e_mongodb_create_and_get.spec.ts
+++ b/packages/integrations/tests/e2e_mongodb_create_and_get.spec.ts
@@ -40,7 +40,7 @@ describe("e2e_mongodb_create_and_get", () => {
     startWorker(worker.journey, ctrl.signal);
 
     // commit event
-    const event1 = await app.journey.commit<LocalEvents["NEW_ACCOUNT_REGISTERED"]>({
+    const event1 = await app.journey.commit<"NEW_ACCOUNT_REGISTERED">({
       type: "NEW_ACCOUNT_REGISTERED",
       payload: {
         id: "123",

--- a/packages/jerni/src/createJourney.ts
+++ b/packages/jerni/src/createJourney.ts
@@ -175,34 +175,27 @@ export default function createJourney(config: JourneyConfig): JourneyInstance {
       }
 
       // $SERVER/events/latest
-      const getLatestUrl = new URL("events/latest", url);
+      // const getLatestUrl = new URL("events/latest", url);
 
-      logger.log("%s sync'ing with server...", INF);
-      const response = await fetch(getLatestUrl.toString(), {
-        headers: {
-          "content-type": "application/json",
-        },
-        signal,
-      });
-      const latestEvent = (await response.json()) as JourneyCommittedEvent;
+      // logger.log("%s sync'ing with server...", INF);
+      // const response = await fetch(getLatestUrl.toString(), {
+      //   headers: {
+      //     "content-type": "application/json",
+      //   },
+      //   signal,
+      // });
+      // const latestEvent = (await response.json()) as JourneyCommittedEvent;
 
-      serverLatest = latestEvent.id;
+      // serverLatest = latestEvent.id;
 
-      // get latest client
+      // logger.debug("%s server latest event id:", DBG, serverLatest);
+      // logger.debug("%s client latest event id:", DBG, clientLatest);
 
-      const lastSeens = await Promise.all(config.stores.map((store) => store.getLastSeenId()));
+      // if (serverLatest > clientLatest) {
+      //   logger.debug("%s catching up...", DBG);
+      // }
 
-      const furthest = Math.min(...lastSeens.filter((id) => id !== null));
-      clientLatest = furthest === Number.POSITIVE_INFINITY ? 0 : furthest;
-
-      logger.debug("%s server latest event id:", DBG, serverLatest);
-      logger.debug("%s client latest event id:", DBG, clientLatest);
-
-      if (serverLatest > clientLatest) {
-        logger.debug("%s catching up...", DBG);
-      }
-
-      subscriptionUrl.searchParams.set("lastEventId", clientLatest.toString());
+      // subscriptionUrl.searchParams.set("lastEventId", clientLatest.toString());
 
       const ev = new MyEventSource(subscriptionUrl.toString(), signal);
 
@@ -281,12 +274,11 @@ function wrapError(errorOrUnknown: unknown): Error {
 const getEventsHandler = function getEventsHandler(config: JourneyConfig) {
   const { logger = defaultLogger, onReport = noop, onError } = config;
 
-  return injectEventDatabase(async function handleEvents(events: JourneyCommittedEvent[]) {
-    logger.debug("%s received %d events", DBG, events.length);
-    try {
-      const eventDatabase = getEventDatabase();
-      await eventDatabase.insertEvents(events);
+  // get latest projected id
+  // const lastSeenIds = await Promise.all(config.stores.map((store) => store.getLastSeenId()));
 
+  // const furthest = Math.min(...lastSeenIds.filter((id) => id !== null));
+  // const clientLatestId = furthest === Number.POSITIVE_INFINITY ? 0 : furthest;
       const output = await Promise.all(
         config.stores.map(async (store) => {
           const output = await singleStoreHandleEvents(store, events);

--- a/packages/jerni/src/createJourney.ts
+++ b/packages/jerni/src/createJourney.ts
@@ -137,7 +137,16 @@ export default function createJourney(config: JourneyConfig): JourneyInstance {
       }
     },
 
-    async *begin(signal?: AbortSignal) {
+    async *begin(externalSignal?: AbortSignal) {
+      // we need another controller so that the background projection can stop the event stream
+      const projectionAbortController = new AbortController();
+
+      // if the external signal is aborted, we should stop the projection
+      externalSignal?.addEventListener("abort", () => {
+        projectionAbortController.abort();
+      });
+
+      const signal = projectionAbortController.signal;
       // we need to resolve all the event types needed
       const includedTypes = new Set<string>();
       let includeAll = false;

--- a/packages/jerni/src/events-storage/__mocks__/sqlite-database.ts
+++ b/packages/jerni/src/events-storage/__mocks__/sqlite-database.ts
@@ -19,13 +19,13 @@ function getSqliteDb(): EventDatabase {
   createQuery.get();
 
   return {
-    getEventsFrom: async (lastEventId: number): Promise<JourneyCommittedEvent[]> => {
-      const query = db.prepare(`SELECT * FROM ${tableName} WHERE id > $lastEventId ORDER BY id ASC`);
-      const events = query.all({ $lastEventId: lastEventId }) as JourneyCommittedEvent[];
+    getEventsFrom: async (lastEventId: number, limit = 200): Promise<JourneyCommittedEvent[]> => {
+      const query = db.prepare(`SELECT * FROM ${tableName} WHERE id > $lastEventId ORDER BY id ASC LIMIT $limit`);
+      const events = query.all({ $lastEventId: lastEventId, $limit: limit }) as JourneyCommittedEvent[];
 
       return events.map((event) => ({
         ...event,
-        payload: JSON.parse(event.payload),
+        payload: JSON.parse(event.payload as string),
       }));
     },
 

--- a/packages/jerni/src/events-storage/injectDatabase.ts
+++ b/packages/jerni/src/events-storage/injectDatabase.ts
@@ -5,6 +5,8 @@ import setup from "src/asynclocal";
 export interface EventDatabase {
   getEventsFrom(lastEventId: number, limit?: number): Promise<JourneyCommittedEvent[]>;
   insertEvents(events: JourneyCommittedEvent[]): Promise<void>;
+
+  streamEventsFrom(lastEventId: number, limit?: number): AsyncGenerator<JourneyCommittedEvent[]>;
 }
 
 async function getDB() {

--- a/packages/jerni/src/events-storage/injectDatabase.ts
+++ b/packages/jerni/src/events-storage/injectDatabase.ts
@@ -3,7 +3,7 @@ import getSqliteDb from "src/events-storage/sqlite-database";
 import setup from "src/asynclocal";
 
 export interface EventDatabase {
-  getEventsFrom(lastEventId: number): Promise<JourneyCommittedEvent[]>;
+  getEventsFrom(lastEventId: number, limit?: number): Promise<JourneyCommittedEvent[]>;
   insertEvents(events: JourneyCommittedEvent[]): Promise<void>;
 }
 

--- a/packages/jerni/src/events-storage/sqlite-database.ts
+++ b/packages/jerni/src/events-storage/sqlite-database.ts
@@ -16,13 +16,13 @@ export default function getSqliteDb(): EventDatabase {
   createQuery.get();
 
   return {
-    getEventsFrom: async (lastEventId: number): Promise<JourneyCommittedEvent[]> => {
-      const query = db.query("SELECT * FROM events WHERE id > $lastEventId ORDER BY id ASC");
-      const events = query.all({ $lastEventId: lastEventId }) as JourneyCommittedEvent[];
+    getEventsFrom: async (lastEventId: number, limit = 200): Promise<JourneyCommittedEvent[]> => {
+      const query = db.query("SELECT * FROM events WHERE id > $lastEventId ORDER BY id ASC LIMIT $limit");
+      const events = query.all({ $lastEventId: lastEventId, $limit: limit }) as JourneyCommittedEvent[];
 
       return events.map((event) => ({
         ...event,
-        payload: JSON.parse(event.payload),
+        payload: JSON.parse(event.payload as string),
       }));
     },
 


### PR DESCRIPTION
## Epic:
- Solve the issue of memory overflow on the Partners Portal

## Planned Tasks:
- Persist received events into a database
- Format project using Biome and its default settings
- Handle the first run path of jerni-3 based on [this Whilsical](https://whimsical.com/jerni-3-flows-4dogv1uFmVddyLj1Gk9597)  ***(You are here 👈)***
- Handle the case where the event database is not up to date
- Handle the case where there are new events are added to the subscription list

## In this PR
- [x] The existing tests should pass since they only represent the first run of the worker
- [x] The projection would be handled in the background
- [x] the begin function only subscribes to the new events, saves them to the database, and triggers the processing on background