### PR TITLE
Handle the case where the event database is not up to date

### DIFF
--- a/packages/integrations/tests/e2e_mongodb_create_and_get.spec.ts
+++ b/packages/integrations/tests/e2e_mongodb_create_and_get.spec.ts
@@ -1,7 +1,6 @@
 import { makeMongoDBStore } from "@jerni/store-mongodb";
 import { describe, it, expect } from "bun:test";
 import createServer from "src/events-server";
-import type { LocalEvents } from "jerni/type";
 import BankAccountModel from "./fixtures/BankAccountModel";
 import initJourney from "./makeTestJourney";
 import startWorker from "./startWorker";
@@ -9,7 +8,7 @@ import cleanUpTestDatabase from "./cleanUpTestDatabase";
 
 describe("e2e_mongodb_create_and_get", () => {
   it("should pass", async () => {
-    const server = createServer();
+    const { server } = createServer();
     const port = server.port;
 
     const dbName = "testsss";

--- a/packages/integrations/tests/e2e_multiple_stores.spec.ts
+++ b/packages/integrations/tests/e2e_multiple_stores.spec.ts
@@ -9,7 +9,7 @@ import cleanUpTestDatabase from "./cleanUpTestDatabase";
 
 describe("e2e_multiple_stores", () => {
   it("should support multiple stores", async () => {
-    const server = createServer();
+    const { server } = createServer();
     const port = server.port;
 
     const dbName = "test-multiple-stores";

--- a/packages/integrations/tests/fixtures/BankAccountModel_2.ts
+++ b/packages/integrations/tests/fixtures/BankAccountModel_2.ts
@@ -1,4 +1,5 @@
 import { MongoDBModel } from "@jerni/store-mongodb";
+import type { MongoOps } from "@jerni/store-mongodb/lib/src/types";
 import mapEvents from "jerni/lib/mapEvents";
 
 interface BankAccountDocumentModel {
@@ -24,7 +25,7 @@ declare module "jerni/type" {
 const model = new MongoDBModel<BankAccountDocumentModel>({
   name: "bank_accounts",
   version: "2",
-  transform: mapEvents({
+  transform: mapEvents<MongoOps<BankAccountDocumentModel>>({
     NEW_ACCOUNT_REGISTERED(event) {
       return {
         insertOne: {

--- a/packages/integrations/tests/handle_errors/handle_error_multiple.spec.ts
+++ b/packages/integrations/tests/handle_errors/handle_error_multiple.spec.ts
@@ -35,7 +35,7 @@ const FailureModel = new MongoDBModel<{ text: string }>({
 
 describe("e2e_handle_errors", () => {
   it("should continue to process if SKIP is returned", async () => {
-    const server = createServer();
+    const { server } = createServer();
     const port = server.port;
 
     const dbName = "handle_errors_with_skip";

--- a/packages/integrations/tests/handle_errors/handle_error_skip.spec.ts
+++ b/packages/integrations/tests/handle_errors/handle_error_skip.spec.ts
@@ -33,7 +33,7 @@ const FailureModel = new MongoDBModel<{ text: string }>({
 
 describe("e2e_handle_errors", () => {
   it("should continue to process if SKIP is returned", async () => {
-    const server = createServer();
+    const { server } = createServer();
     const port = server.port;
 
     const dbName = "handle_errors_with_skip";

--- a/packages/integrations/tests/handle_errors/handle_errors.spec.ts
+++ b/packages/integrations/tests/handle_errors/handle_errors.spec.ts
@@ -26,7 +26,7 @@ const FailureModel = new MongoDBModel({
 
 describe("e2e_handle_errors", () => {
   it("should report error", async () => {
-    const server = createServer();
+    const { server } = createServer();
     const port = server.port;
 
     const dbName = "handle_errors";

--- a/packages/integrations/tests/handle_errors/handle_errors_pinpoint.spec.ts
+++ b/packages/integrations/tests/handle_errors/handle_errors_pinpoint.spec.ts
@@ -34,7 +34,7 @@ const FailureModel = new MongoDBModel<{ text: string }>({
 
 describe("e2e_handle_errors", () => {
   it("should pinpoint the offending event", async () => {
-    const server = createServer();
+    const { server } = createServer();
     const port = server.port;
 
     const dbName = "handle_errors_pin_point";

--- a/packages/jerni/src/MyEventSource.ts
+++ b/packages/jerni/src/MyEventSource.ts
@@ -441,6 +441,12 @@ export default class MyEventSource extends EventTarget {
     this.#is_tls = uri.protocol === "https:";
     this.#url = uri;
     this.#state = 2;
+    // check if the url contains search params lastEventId then set it
+    if (uri.searchParams.has("lastEventId")) {
+      this.#lastEventID = uri.searchParams.get("lastEventId") || "";
+      // delete the lastEventId from the search params so that does not conflict with the last-event-id header
+      uri.searchParams.delete("lastEventId");
+    }
     process.nextTick(MyEventSource.#ConnectNextTick, this);
 
     if (signal) {

--- a/packages/jerni/src/createJourney.ts
+++ b/packages/jerni/src/createJourney.ts
@@ -176,27 +176,29 @@ export default function createJourney(config: JourneyConfig): JourneyInstance {
       }
 
       // $SERVER/events/latest
-      // const getLatestUrl = new URL("events/latest", url);
+      const getLatestUrl = new URL("events/latest", url);
 
-      // logger.log("%s sync'ing with server...", INF);
-      // const response = await fetch(getLatestUrl.toString(), {
-      //   headers: {
-      //     "content-type": "application/json",
-      //   },
-      //   signal,
-      // });
-      // const latestEvent = (await response.json()) as JourneyCommittedEvent;
+      logger.log("%s sync'ing with server...", INF);
+      const response = await fetch(getLatestUrl.toString(), {
+        headers: {
+          "content-type": "application/json",
+        },
+        signal,
+      });
+      const latestEvent = (await response.json()) as JourneyCommittedEvent;
 
-      // serverLatest = latestEvent.id;
+      const clientLatest = await getLatestSavedEventId();
 
-      // logger.debug("%s server latest event id:", DBG, serverLatest);
-      // logger.debug("%s client latest event id:", DBG, clientLatest);
+      const serverLatest = latestEvent.id;
 
-      // if (serverLatest > clientLatest) {
-      //   logger.debug("%s catching up...", DBG);
-      // }
+      logger.debug("%s server latest event id:", DBG, serverLatest);
+      logger.debug("%s client latest event id:", DBG, clientLatest);
 
-      // subscriptionUrl.searchParams.set("lastEventId", clientLatest.toString());
+      if (serverLatest > clientLatest) {
+        logger.debug("%s catching up...", DBG);
+      }
+
+      subscriptionUrl.searchParams.set("lastEventId", clientLatest.toString());
 
       const ev = new MyEventSource(subscriptionUrl.toString(), signal);
 
@@ -417,4 +419,8 @@ const scheduleHandleEvents = injectEventDatabase(async function scheduleHandleEv
       }
     }
   }
+});
+
+const getLatestSavedEventId = injectEventDatabase(async function getLatestSavedEventId() {
+  return getEventDatabase().getLatestEventId();
 });

--- a/packages/jerni/src/events-storage/__mocks__/sqlite-database.ts
+++ b/packages/jerni/src/events-storage/__mocks__/sqlite-database.ts
@@ -61,6 +61,13 @@ function getSqliteDb(): EventDatabase {
         currentId = events[events.length - 1].id;
       }
     },
+
+    getLatestEventId: async () => {
+      const query = db.query(`SELECT MAX(id) as maxId FROM ${tableName}`);
+      const { maxId } = query.get() as { maxId: number };
+
+      return maxId || 0;
+    },
   };
 }
 

--- a/packages/jerni/src/events-storage/injectDatabase.ts
+++ b/packages/jerni/src/events-storage/injectDatabase.ts
@@ -5,8 +5,8 @@ import setup from "src/asynclocal";
 export interface EventDatabase {
   getEventsFrom(lastEventId: number, limit?: number): Promise<JourneyCommittedEvent[]>;
   insertEvents(events: JourneyCommittedEvent[]): Promise<void>;
-
   streamEventsFrom(lastEventId: number, limit?: number): AsyncGenerator<JourneyCommittedEvent[]>;
+  getLatestEventId(): Promise<number>;
 }
 
 async function getDB() {

--- a/packages/jerni/src/events-storage/sqlite-database.ts
+++ b/packages/jerni/src/events-storage/sqlite-database.ts
@@ -58,5 +58,12 @@ export default function getSqliteDb(): EventDatabase {
         });
       }
     },
+
+    getLatestEventId: async () => {
+      const query = db.query("SELECT MAX(id) as maxId FROM events");
+      const { maxId } = query.get() as { maxId: number };
+
+      return maxId || 0;
+    },
   };
 }

--- a/packages/jerni/src/tests/persist-event-to-file-system.spec.ts
+++ b/packages/jerni/src/tests/persist-event-to-file-system.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { getEventDatabase, injectEventDatabase } from "src/events-storage/injectDatabase";
-import createServer from "../helpers/events-server";
-import { initJourney } from "../helpers/initJourney";
+import createServer from "./helpers/events-server";
+import { initJourney } from "./helpers/initJourney";
 
 import "src/events-storage/__mocks__/sqlite-database";
 

--- a/packages/jerni/src/tests/subscribe-from-last-saved-event-id.spec.ts
+++ b/packages/jerni/src/tests/subscribe-from-last-saved-event-id.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import { makeMongoDBStore } from "@jerni/store-mongodb";
+import { MongoClient } from "mongodb";
+import { createServer, initJourney, startWorker } from "integration-test-jerni";
+import { BankAccountModel } from "integration-test-jerni/models";
+import { injectEventDatabase } from "src/events-storage/injectDatabase";
+import { setTimeout } from "node:timers/promises";
+
+import "src/events-storage/__mocks__/sqlite-database";
+
+test(
+  "start subscription from last saved event id",
+  injectEventDatabase(async () => {
+    const { server, inputSpies } = createServer();
+    const port = server.port;
+
+    const dbName = "testsss";
+
+    // clean up the database
+    const client = await MongoClient.connect("mongodb://127.1:27017");
+    const db = client.db(dbName);
+    await db.dropDatabase();
+    await client.close();
+
+    const ctrl1 = new AbortController();
+    const ctrl2 = new AbortController();
+
+    const storeMongoDbForWorker = await makeMongoDBStore({
+      name: "mongodb-app",
+      url: "mongodb://127.1:27017/",
+      dbName,
+      models: [BankAccountModel],
+    });
+
+    const worker = await initJourney([storeMongoDbForWorker], port);
+
+    // commit event, this should be trigger from app, but for testing purpose, we trigger it from worker
+    const event1 = await worker.journey.commit<"NEW_ACCOUNT_REGISTERED">({
+      type: "NEW_ACCOUNT_REGISTERED",
+      payload: {
+        id: "123",
+        name: "test",
+      },
+    });
+
+    // STEP 1: listen to the first event then terminate the worker
+    // start worker
+    startWorker(worker.journey, ctrl1.signal);
+
+    await worker.journey.waitFor(event1);
+
+    ctrl1.abort();
+
+    // STEP 2: start worker again, expect the worker subscribe with last-event-id = 1
+    startWorker(worker.journey, ctrl2.signal);
+
+    // wait for the worker to start and subscribe
+    await setTimeout(300);
+
+    ctrl2.abort();
+
+    const lastCall = inputSpies.subscriptionInputSpy.mock.calls[inputSpies.subscriptionInputSpy.mock.calls.length - 1];
+    expect(lastCall[1].headers.get("last-event-id")).toBe("1");
+  }),
+);

--- a/packages/jerni/src/tests/subscribe-from-last-saved-event-id.spec.ts
+++ b/packages/jerni/src/tests/subscribe-from-last-saved-event-id.spec.ts
@@ -2,9 +2,8 @@ import { expect, test } from "bun:test";
 import { makeMongoDBStore } from "@jerni/store-mongodb";
 import { MongoClient } from "mongodb";
 import { createServer, initJourney, startWorker } from "integration-test-jerni";
-import { BankAccountModel } from "integration-test-jerni/models";
+import { BankAccountModel_2 } from "integration-test-jerni/models";
 import { injectEventDatabase } from "src/events-storage/injectDatabase";
-import { setTimeout } from "node:timers/promises";
 
 import "src/events-storage/__mocks__/sqlite-database";
 
@@ -29,13 +28,13 @@ test(
       name: "mongodb-app",
       url: "mongodb://127.1:27017/",
       dbName,
-      models: [BankAccountModel],
+      models: [BankAccountModel_2],
     });
 
     const worker = await initJourney([storeMongoDbForWorker], port);
 
     // commit event, this should be trigger from app, but for testing purpose, we trigger it from worker
-    const event1 = await worker.journey.commit<"NEW_ACCOUNT_REGISTERED">({
+    const event1 = await worker.journey.commit({
       type: "NEW_ACCOUNT_REGISTERED",
       payload: {
         id: "123",
@@ -51,15 +50,29 @@ test(
 
     ctrl1.abort();
 
+    const event2 = await worker.journey.append({
+      type: "ACCOUNT_DEPOSITED",
+      payload: {
+        id: "123",
+        amount: 100,
+      },
+    });
+
     // STEP 2: start worker again, expect the worker subscribe with last-event-id = 1
     startWorker(worker.journey, ctrl2.signal);
 
-    // wait for the worker to start and subscribe
-    await setTimeout(300);
+    await worker.journey.waitFor(event2);
 
     ctrl2.abort();
 
     const lastCall = inputSpies.subscriptionInputSpy.mock.calls[inputSpies.subscriptionInputSpy.mock.calls.length - 1];
     expect(lastCall[1].headers.get("last-event-id")).toBe("1");
+
+    const BankAccounts = await worker.journey.getReader(BankAccountModel_2);
+    const bankAccount = await BankAccounts.findOne({
+      id: "123",
+    });
+
+    expect(bankAccount.balance).toEqual(100);
   }),
 );


### PR DESCRIPTION
## Epic:
- Solve the issue of memory overflow on the Partners Portal

## Planned Tasks:
- Format project using Biome and its default settings
- Handle the first run path of jerni-3 based on [this Whilsical](https://whimsical.com/jerni-3-flows-4dogv1uFmVddyLj1Gk9597)
- Handle the case where the event database is not up to date  ***(You are here 👈)***
- Handle cross-model readPipeline simple version 
- Handle the case where there are new events are added to the subscription list

## In this PR
- [x] Add test to verify that the subscription only start from the last saved event id
- [x] Test to make sure the new events are also projected