### PR TITLE
Handle the case where there are new events are added to the subscription list

### DIFF
--- a/packages/integrations/tests/cleanUpTestDatabase.ts
+++ b/packages/integrations/tests/cleanUpTestDatabase.ts
@@ -11,6 +11,6 @@ export default async function cleanUpTestDatabase(dbName: string) {
   await client.close();
 
   // clean up the sqlite
-  const query = sqliteDb.query("DROP TABLE IF EXISTS events");
-  query.get();
+  sqliteDb.query("DELETE FROM events").run();
+  sqliteDb.query("DELETE FROM snapshot").run();
 }

--- a/packages/jerni-store-mongodb/src/read.ts
+++ b/packages/jerni-store-mongodb/src/read.ts
@@ -19,8 +19,6 @@ export class Signal<DocumentType extends Document> {
 
     const res = await collection.aggregate(this.pipeline).toArray();
 
-    console.log("executed signal for model=%s, got:", this.model.name, res);
-
     // write to the slot
     let slots = modelSlotsMap.get(this.model);
 

--- a/packages/jerni/src/createJourney.ts
+++ b/packages/jerni/src/createJourney.ts
@@ -138,11 +138,12 @@ export default function createJourney(config: JourneyConfig): JourneyInstance {
     async *begin(externalSignal?: AbortSignal) {
       // we need another controller so that the background projection can stop the event stream
       const projectionAbortController = new AbortController();
-
-      // if the external signal is aborted, we should stop the projection
-      externalSignal?.addEventListener("abort", () => {
+      function abort() {
+        console.log("aborting projection...");
         projectionAbortController.abort();
-      });
+      }
+      // if the external signal is aborted, we should stop the projection
+      externalSignal?.addEventListener("abort", abort);
 
       const signal = projectionAbortController.signal;
 
@@ -230,11 +231,9 @@ export default function createJourney(config: JourneyConfig): JourneyInstance {
         void scheduleHandleEvents(config, projectionAbortController);
       }
 
-      if (signal?.aborted) {
-        // log that the journey worker has been stopped by abort signal
-        logger.debug("aborting journey...");
-        ev.close();
-      }
+      // dispose all listeners
+      ev.close();
+      externalSignal?.removeEventListener("abort", abort);
 
       return;
     },

--- a/packages/jerni/src/createJourney.ts
+++ b/packages/jerni/src/createJourney.ts
@@ -133,6 +133,9 @@ export default function createJourney(config: JourneyConfig): JourneyInstance {
       for (const store of config.stores) {
         await store.dispose();
       }
+
+      // dispose all events
+      await disposeAllEvents();
     },
 
     async *begin(externalSignal?: AbortSignal) {
@@ -435,4 +438,8 @@ const getLatestSavedEventId = injectEventDatabase(async function getLatestSavedE
   const hashed = getHashedIncludes(includes);
 
   return getEventDatabase().getLatestEventId(hashed);
+});
+
+const disposeAllEvents = injectEventDatabase(async function disposeAllEvents() {
+  return getEventDatabase().dispose();
 });

--- a/packages/jerni/src/createJourney.ts
+++ b/packages/jerni/src/createJourney.ts
@@ -18,6 +18,7 @@ import { DBG, INF } from "./cli-utils/log-headers";
 import { bold } from "picocolors";
 import { getEventDatabase, injectEventDatabase } from "./events-storage/injectDatabase";
 import listen from "./listen";
+import hash from "hash-sum";
 
 const defaultLogger = console;
 const noop = () => {};
@@ -187,7 +188,7 @@ export default function createJourney(config: JourneyConfig): JourneyInstance {
       });
       const latestEvent = (await response.json()) as JourneyCommittedEvent;
 
-      const clientLatest = await getLatestSavedEventId();
+      const clientLatest = await getLatestSavedEventId(includedTypes);
 
       const serverLatest = latestEvent.id;
 
@@ -221,7 +222,7 @@ export default function createJourney(config: JourneyConfig): JourneyInstance {
       for await (const stream of eventStream) {
         const data = JSON.parse(stream) as JourneyCommittedEvent[];
 
-        await saveEvents(data);
+        await saveEvents(includedTypes, data);
 
         yield data;
 
@@ -268,9 +269,14 @@ function wrapError(errorOrUnknown: unknown): Error {
   return new Error(JSON.stringify(errorOrUnknown));
 }
 
-const saveEvents = injectEventDatabase(async function handleEvents(events: JourneyCommittedEvent[]) {
+const saveEvents = injectEventDatabase(async function handleEvents(
+  includeList: Set<string>,
+  events: JourneyCommittedEvent[],
+) {
+  const hashed = getHashedIncludes(Array.from(includeList).sort());
+
   const eventDatabase = getEventDatabase();
-  await eventDatabase.insertEvents(events);
+  await eventDatabase.insertEvents(hashed, events);
 });
 
 let projecting = false;
@@ -421,6 +427,13 @@ const scheduleHandleEvents = injectEventDatabase(async function scheduleHandleEv
   }
 });
 
-const getLatestSavedEventId = injectEventDatabase(async function getLatestSavedEventId() {
-  return getEventDatabase().getLatestEventId();
+function getHashedIncludes(includes: string[]) {
+  return hash(includes.sort());
+}
+
+const getLatestSavedEventId = injectEventDatabase(async function getLatestSavedEventId(includedTypes: Set<string>) {
+  const includes = Array.from(includedTypes);
+  const hashed = getHashedIncludes(includes);
+
+  return getEventDatabase().getLatestEventId(hashed);
 });

--- a/packages/jerni/src/events-storage/__mocks__/sqlite-database.ts
+++ b/packages/jerni/src/events-storage/__mocks__/sqlite-database.ts
@@ -6,21 +6,27 @@ import { mock } from "bun:test";
 const db = new Database(":memory:");
 
 function getSqliteDb(): EventDatabase {
-  const tableName = `events_${Math.random().toString(36).slice(2)}`;
+  const eventsTableName = `events_${Math.random().toString(36).slice(2)}`;
+  const snapshotTableName = `snapshot_${Math.random().toString(36).slice(2)}`;
 
-  const createQuery = db.query(`
-  CREATE TABLE IF NOT EXISTS ${tableName} (
+  db.query(`
+  CREATE TABLE IF NOT EXISTS ${eventsTableName} (
     id INTEGER PRIMARY KEY,
     type TEXT NOT NULL,
     payload TEXT NOT NULL
   );
-`);
+`).get();
 
-  createQuery.get();
+  db.query(`
+  CREATE TABLE IF NOT EXISTS ${snapshotTableName} (
+    id TEXT PRIMARY KEY,
+    LAST_EVENT_ID INTEGER NOT NULL
+  );
+`).get();
 
   return {
     getEventsFrom: async (lastEventId: number, limit = 200): Promise<JourneyCommittedEvent[]> => {
-      const query = db.prepare(`SELECT * FROM ${tableName} WHERE id > $lastEventId ORDER BY id ASC LIMIT $limit`);
+      const query = db.prepare(`SELECT * FROM ${eventsTableName} WHERE id > $lastEventId ORDER BY id ASC LIMIT $limit`);
       const events = query.all({ $lastEventId: lastEventId, $limit: limit }) as JourneyCommittedEvent[];
 
       return events.map((event) => ({
@@ -29,8 +35,11 @@ function getSqliteDb(): EventDatabase {
       }));
     },
 
-    insertEvents: async (events: JourneyCommittedEvent[]) => {
-      const insertQuery = db.prepare(`INSERT INTO ${tableName} (id ,type, payload) VALUES ($id, $type, $payload)`);
+    insertEvents: async (includeListHash, events: JourneyCommittedEvent[]) => {
+      // upsert events
+      const insertQuery = db.prepare(
+        `INSERT OR REPLACE INTO ${eventsTableName} (id, type, payload) VALUES ($id, $type, $payload)`,
+      );
 
       for (const event of events) {
         insertQuery.run({
@@ -39,10 +48,16 @@ function getSqliteDb(): EventDatabase {
           $payload: JSON.stringify(event.payload),
         });
       }
+
+      const lastEventId = events[events.length - 1].id;
+      const query = db.prepare(
+        `INSERT OR REPLACE INTO ${snapshotTableName} (id, LAST_EVENT_ID) VALUES ($id, $lastEventId)`,
+      );
+      query.run({ $id: includeListHash, $lastEventId: lastEventId });
     },
 
     streamEventsFrom: async function* (lastEventId: number, limit = 200): AsyncGenerator<JourneyCommittedEvent[]> {
-      const query = db.prepare(`SELECT * FROM ${tableName} WHERE id > $lastEventId ORDER BY id ASC LIMIT $limit`);
+      const query = db.prepare(`SELECT * FROM ${eventsTableName} WHERE id > $lastEventId ORDER BY id ASC LIMIT $limit`);
 
       let currentId = lastEventId;
 
@@ -62,11 +77,11 @@ function getSqliteDb(): EventDatabase {
       }
     },
 
-    getLatestEventId: async () => {
-      const query = db.query(`SELECT MAX(id) as maxId FROM ${tableName}`);
-      const { maxId } = query.get() as { maxId: number };
+    getLatestEventId: async (includeListHash) => {
+      const query = db.prepare(`SELECT LAST_EVENT_ID FROM ${snapshotTableName} WHERE id = $id`);
+      const row = query.get({ $id: includeListHash }) as { LAST_EVENT_ID: number } | undefined;
 
-      return maxId || 0;
+      return row ? row.LAST_EVENT_ID : 0;
     },
   };
 }

--- a/packages/jerni/src/events-storage/__mocks__/sqlite-database.ts
+++ b/packages/jerni/src/events-storage/__mocks__/sqlite-database.ts
@@ -83,6 +83,11 @@ function getSqliteDb(): EventDatabase {
 
       return row ? row.LAST_EVENT_ID : 0;
     },
+
+    dispose: async () => {
+      db.query(`DROP TABLE ${eventsTableName}`).get();
+      db.query(`DROP TABLE ${snapshotTableName}`).get();
+    },
   };
 }
 

--- a/packages/jerni/src/events-storage/injectDatabase.ts
+++ b/packages/jerni/src/events-storage/injectDatabase.ts
@@ -4,9 +4,10 @@ import setup from "src/asynclocal";
 
 export interface EventDatabase {
   getEventsFrom(lastEventId: number, limit?: number): Promise<JourneyCommittedEvent[]>;
-  insertEvents(events: JourneyCommittedEvent[]): Promise<void>;
+  insertEvents(includesListHash: string, events: JourneyCommittedEvent[]): Promise<void>;
   streamEventsFrom(lastEventId: number, limit?: number): AsyncGenerator<JourneyCommittedEvent[]>;
-  getLatestEventId(): Promise<number>;
+
+  getLatestEventId(includesListHash: string): Promise<number>;
 }
 
 async function getDB() {

--- a/packages/jerni/src/events-storage/injectDatabase.ts
+++ b/packages/jerni/src/events-storage/injectDatabase.ts
@@ -8,6 +8,8 @@ export interface EventDatabase {
   streamEventsFrom(lastEventId: number, limit?: number): AsyncGenerator<JourneyCommittedEvent[]>;
 
   getLatestEventId(includesListHash: string): Promise<number>;
+
+  dispose(): Promise<void>;
 }
 
 async function getDB() {

--- a/packages/jerni/src/events-storage/sqlite-database.ts
+++ b/packages/jerni/src/events-storage/sqlite-database.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import type { JourneyCommittedEvent } from "jerni/type";
 import type { EventDatabase } from "./injectDatabase";
 
-const db = new Database("events.sqlite");
+const db = new Database("mydb.sqlite");
 
 export default function getSqliteDb(): EventDatabase {
   // create tables if not exists
@@ -76,6 +76,12 @@ export default function getSqliteDb(): EventDatabase {
       const row = query.get({ $id: includeListHash }) as { LAST_EVENT_ID: number } | undefined;
 
       return row ? row.LAST_EVENT_ID : 0;
+    },
+
+    dispose: async () => {
+      // delete all events and snapshot
+      db.query("DELETE FROM events").run();
+      db.query("DELETE FROM snapshot").run();
     },
   };
 }

--- a/packages/jerni/src/tests/helpers/events-server.ts
+++ b/packages/jerni/src/tests/helpers/events-server.ts
@@ -1,6 +1,6 @@
-import { Database } from "bun:sqlite";
 import { mock } from "bun:test";
 import type { JourneyCommittedEvent } from "../../types/events";
+import { URL } from "node:url";
 
 export default function createServer(events: JourneyCommittedEvent[], subscriptionInterval = 300) {
   const subscriptionInputSpy = mock((searchParams: string, req: Request) => {});
@@ -30,7 +30,7 @@ export default function createServer(events: JourneyCommittedEvent[], subscripti
         return Response.json(events[events.length - 1]);
       }
 
-      // 3. GET /subscribe
+      // 2. GET /subscribe
       if (req.method === "GET" && url.pathname === "/subscribe") {
         subscriptionInputSpy(url.searchParams.toString(), req);
 
@@ -52,8 +52,20 @@ export default function createServer(events: JourneyCommittedEvent[], subscripti
   async function streamingResponse(req: Request, events: JourneyCommittedEvent[]) {
     const signal = req.signal;
 
+    const url = new URL(req.url);
+
     // get last event id from req headers
     const lastEventId = req.headers.get("Last-Event-ID");
+
+    const includes = url.searchParams.get("includes");
+    const includeList = includes ? includes.split(",") : [];
+    const isInIncludeList = (event: JourneyCommittedEvent) => {
+      if (includeList.length === 0) {
+        return true;
+      }
+
+      return includeList.includes(event.type as string);
+    };
 
     // write headers
     const headers = {
@@ -74,8 +86,14 @@ export default function createServer(events: JourneyCommittedEvent[], subscripti
           controller.write(":ok\n\n");
 
           do {
-            // query for new events
-            const rows = events.filter((event) => event.id > lastReturned);
+            // get a batch of events to send
+            const batch = events.slice(lastReturned, lastReturned + 200);
+
+            // update lastReturned to mark the first event for the next batch
+            lastReturned += batch.length;
+
+            // only include events that are in the include list
+            const rows = batch.filter(isInIncludeList);
 
             // if empty, wait for 1 second
             if (rows.length === 0) {
@@ -84,7 +102,6 @@ export default function createServer(events: JourneyCommittedEvent[], subscripti
             }
 
             const last = rows[rows.length - 1];
-            lastReturned = last.id;
 
             // check if client is still connected
             if (signal.aborted) {

--- a/packages/jerni/src/tests/helpers/events-server.ts
+++ b/packages/jerni/src/tests/helpers/events-server.ts
@@ -87,19 +87,19 @@ export default function createServer(events: JourneyCommittedEvent[], subscripti
 
           do {
             // get a batch of events to send
-            const batch = events.slice(lastReturned, lastReturned + 200);
+            const batch = events.slice(lastReturned, lastReturned + 10);
 
             // update lastReturned to mark the first event for the next batch
             lastReturned += batch.length;
 
-            // only include events that are in the include list
-            const rows = batch.filter(isInIncludeList);
-
             // if empty, wait for 1 second
-            if (rows.length === 0) {
+            if (batch.length === 0) {
               await Bun.sleep(subscriptionInterval);
               continue;
             }
+
+            // only include events that are in the include list
+            const rows = batch.filter(isInIncludeList);
 
             const last = rows[rows.length - 1];
 

--- a/packages/jerni/src/tests/new-events-added-to-subscription-list.spec.ts
+++ b/packages/jerni/src/tests/new-events-added-to-subscription-list.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { getEventDatabase, injectEventDatabase } from "src/events-storage/injectDatabase";
+import createServer from "./helpers/events-server";
+import { initJourney } from "./helpers/initJourney";
+import type { Store } from "src/types/config";
+
+import "src/events-storage/__mocks__/sqlite-database";
+
+function getMockStore(config: Partial<Store>) {
+  return {
+    meta: {
+      includes: [],
+    },
+    registerModels: () => {},
+    handleEvents: () => {},
+    ...config,
+  } as unknown as Store;
+}
+
+describe("New events added to subscription list", () => {
+  test(
+    "if new events are added to the subscription list, the worker should subscribe from the beginning and persist the new events",
+    injectEventDatabase(async () => {
+      // SETUP: a server with 2 events
+      const { server, inputSpies } = createServer([
+        {
+          id: 1,
+          type: "NEW_ACCOUNT_REGISTERED",
+          payload: {
+            id: "123",
+            name: "test",
+          },
+        },
+        {
+          id: 2,
+          type: "ACCOUNT_UPDATED",
+          payload: {
+            id: "123",
+            name: "test-updated",
+          },
+        },
+      ]);
+      const eventServerUrl = `http://localhost:${server.port}`;
+
+      // SETUP: worker subscribes to only 1 event type, and persists the event
+      const ctrl = new AbortController();
+
+      const worker1 = await initJourney(eventServerUrl, [
+        getMockStore({
+          meta: {
+            includes: ["ACCOUNT_UPDATED"],
+          },
+        }),
+      ]);
+
+      // stop after the first event is processed and yielded
+      for await (const _events of worker1.journey.begin(ctrl.signal)) {
+        ctrl.abort();
+      }
+
+      // only 1 event is persisted
+      const eventDatabase = getEventDatabase();
+      const persistedEvents = await eventDatabase.getEventsFrom(0);
+      expect(persistedEvents).toEqual([
+        {
+          id: 2,
+          type: "ACCOUNT_UPDATED",
+          payload: {
+            id: "123",
+            name: "test-updated",
+          },
+        },
+      ]);
+
+      // TEST: worker subscribes to 2 event types, the earlier event should also be included in the persisted events
+      const worker2 = await initJourney(eventServerUrl, [
+        getMockStore({
+          meta: {
+            includes: ["NEW_ACCOUNT_REGISTERED", "ACCOUNT_UPDATED"],
+          },
+        }),
+      ]);
+
+      const ctrl2 = new AbortController();
+
+      for await (const _events of worker2.journey.begin(ctrl2.signal)) {
+        ctrl2.abort();
+      }
+
+      // expect both the event types to be added in the includes list
+      const lastCall =
+        inputSpies.subscriptionInputSpy.mock.calls[inputSpies.subscriptionInputSpy.mock.calls.length - 1];
+      const searchParams = lastCall[0];
+      const expectedParams = new URLSearchParams({
+        includes: "NEW_ACCOUNT_REGISTERED,ACCOUNT_UPDATED",
+      });
+
+      expect(expectedParams.toString()).toEqual(searchParams);
+
+      // expect subscribe from the beginning when there is a new event in the includes list
+      const req = lastCall[1];
+      const lastEventId = req.headers.get("Last-Event-ID");
+
+      expect(lastEventId).toEqual("0");
+
+      // expect the new event to be persisted
+      const persistedEvents2 = await eventDatabase.getEventsFrom(0);
+      expect(persistedEvents2).toEqual([
+        {
+          id: 1,
+          type: "NEW_ACCOUNT_REGISTERED",
+          payload: {
+            id: "123",
+            name: "test",
+          },
+        },
+        {
+          id: 2,
+          type: "ACCOUNT_UPDATED",
+          payload: {
+            id: "123",
+            name: "test-updated",
+          },
+        },
+      ]);
+    }),
+  );
+});

--- a/packages/jerni/src/tests/subscribe-from-last-saved-event-id.spec.ts
+++ b/packages/jerni/src/tests/subscribe-from-last-saved-event-id.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import { getEventDatabase, injectEventDatabase } from "src/events-storage/injectDatabase";
 import createServer from "./helpers/events-server";
 import { initJourney } from "./helpers/initJourney";
+import hash from "hash-sum";
 
 import "src/events-storage/__mocks__/sqlite-database";
 
@@ -10,7 +11,7 @@ test(
   injectEventDatabase(async () => {
     // Setup: there is an event already saved in the database
     const eventDatabase = getEventDatabase();
-    eventDatabase.insertEvents([
+    eventDatabase.insertEvents(hash([]), [
       {
         id: 1,
         type: "NEW_ACCOUNT_REGISTERED",

--- a/packages/jerni/src/tests/subscribe-from-last-saved-event-id.spec.ts
+++ b/packages/jerni/src/tests/subscribe-from-last-saved-event-id.spec.ts
@@ -1,78 +1,80 @@
 import { expect, test } from "bun:test";
-import { makeMongoDBStore } from "@jerni/store-mongodb";
-import { MongoClient } from "mongodb";
-import { createServer, initJourney, startWorker } from "integration-test-jerni";
-import { BankAccountModel_2 } from "integration-test-jerni/models";
-import { injectEventDatabase } from "src/events-storage/injectDatabase";
+import { getEventDatabase, injectEventDatabase } from "src/events-storage/injectDatabase";
+import createServer from "./helpers/events-server";
+import { initJourney } from "./helpers/initJourney";
 
 import "src/events-storage/__mocks__/sqlite-database";
 
 test(
   "start subscription from last saved event id",
   injectEventDatabase(async () => {
-    const { server, inputSpies } = createServer();
-    const port = server.port;
-
-    const dbName = "testsss";
-
-    // clean up the database
-    const client = await MongoClient.connect("mongodb://127.1:27017");
-    const db = client.db(dbName);
-    await db.dropDatabase();
-    await client.close();
-
-    const ctrl1 = new AbortController();
-    const ctrl2 = new AbortController();
-
-    const storeMongoDbForWorker = await makeMongoDBStore({
-      name: "mongodb-app",
-      url: "mongodb://127.1:27017/",
-      dbName,
-      models: [BankAccountModel_2],
-    });
-
-    const worker = await initJourney([storeMongoDbForWorker], port);
-
-    // commit event, this should be trigger from app, but for testing purpose, we trigger it from worker
-    const event1 = await worker.journey.commit({
-      type: "NEW_ACCOUNT_REGISTERED",
-      payload: {
-        id: "123",
-        name: "test",
+    // Setup: there is an event already saved in the database
+    const eventDatabase = getEventDatabase();
+    eventDatabase.insertEvents([
+      {
+        id: 1,
+        type: "NEW_ACCOUNT_REGISTERED",
+        payload: {
+          id: "123",
+          name: "test",
+        },
       },
-    });
+    ]);
 
-    // STEP 1: listen to the first event then terminate the worker
-    // start worker
-    startWorker(worker.journey, ctrl1.signal);
-
-    await worker.journey.waitFor(event1);
-
-    ctrl1.abort();
-
-    const event2 = await worker.journey.append({
-      type: "ACCOUNT_DEPOSITED",
-      payload: {
-        id: "123",
-        amount: 100,
+    // Setup: create an events server that has 2 events
+    const { server, inputSpies } = createServer([
+      {
+        id: 1,
+        type: "NEW_ACCOUNT_REGISTERED",
+        payload: {
+          id: "123",
+          name: "test",
+        },
       },
-    });
+      {
+        id: 2,
+        type: "ACCOUNT_DEPOSITED",
+        payload: {
+          id: "123",
+          amount: 100,
+        },
+      },
+    ]);
 
-    // STEP 2: start worker again, expect the worker subscribe with last-event-id = 1
-    startWorker(worker.journey, ctrl2.signal);
+    const eventServerUrl = `http://localhost:${server.port}`;
 
-    await worker.journey.waitFor(event2);
+    const ctrl = new AbortController();
 
-    ctrl2.abort();
+    const worker = await initJourney(eventServerUrl, []);
 
+    // subscribe to events
+    for await (const _events of worker.journey.begin(ctrl.signal)) {
+      ctrl.abort();
+    }
+
+    // check that the last event id is sent in the headers
     const lastCall = inputSpies.subscriptionInputSpy.mock.calls[inputSpies.subscriptionInputSpy.mock.calls.length - 1];
     expect(lastCall[1].headers.get("last-event-id")).toBe("1");
 
-    const BankAccounts = await worker.journey.getReader(BankAccountModel_2);
-    const bankAccount = await BankAccounts.findOne({
-      id: "123",
-    });
-
-    expect(bankAccount.balance).toEqual(100);
+    // check that the events are persisted in the database
+    const events = await eventDatabase.getEventsFrom(0);
+    expect(events).toEqual([
+      {
+        id: 1,
+        type: "NEW_ACCOUNT_REGISTERED",
+        payload: {
+          id: "123",
+          name: "test",
+        },
+      },
+      {
+        id: 2,
+        type: "ACCOUNT_DEPOSITED",
+        payload: {
+          id: "123",
+          amount: 100,
+        },
+      },
+    ]);
   }),
 );

--- a/packages/jerni/src/types/journey.ts
+++ b/packages/jerni/src/types/journey.ts
@@ -21,7 +21,8 @@ export interface JourneyInstance {
   dispose: () => Promise<void>;
 
   // async generator `begin` that start the subscription
-  begin: (signal: AbortSignal) => AsyncGenerator<JourneyCommittedEvent[]>;
+  // biome-ignore lint/suspicious/noExplicitAny: because this is a placeholder, the client that uses jerni would override this type
+  begin: (signal: AbortSignal) => AsyncGenerator<any>;
 }
 
 // placeholder for getReader function


### PR DESCRIPTION
## Epic:
- Solve the issue of memory overflow on the Partners Portal
- Design Flow in [this Whilsical](https://whimsical.com/jerni-3-flows-4dogv1uFmVddyLj1Gk9597)

## Planned Tasks:
- Handle the case where the event database is not up to date  
- Handle cross-model readPipeline simple version
- Handle the case where there are new events are added to the subscription list ***(You are here 👈)***
- Setup Docker compose to verify the current implementation works
- Handle the case where the having to project a not up-to-date collection

## In this PR
- [x] Mock events server also process the `includes` search params
- [x] Test to make sure the events are subscribed from start when there are new events in include list
- [x] Subscribe from event id 0 when there are new events in the includes list