### PR TITLE
fix(download-binary): read version from the script's package.json instead of the executed folder's package.json

### DIFF
--- a/packages/jerni/jsr.json
+++ b/packages/jerni/jsr.json
@@ -9,10 +9,5 @@
     "./lib/errors/UnrecoverableError": "./src/UnrecoverableError.ts",
     "./lib/skip": "./src/lib/skip.ts"
   },
-  "exclude": [
-    "src/tests",
-    "src/worker.ts",
-    "src/cli.ts",
-    "src/begin.ts"
-  ]
+  "exclude": ["src/tests", "src/worker.ts", "src/cli.ts", "src/begin.ts"]
 }

--- a/packages/jerni/package.json
+++ b/packages/jerni/package.json
@@ -3,7 +3,9 @@
   "version": "v0.1.6",
   "type": "module",
   "main": "src/index.ts",
-  "bin": "./scripts/run-cli.js",
+  "bin": {
+    "start-journey": "./scripts/run-cli.js"
+  },
   "dependencies": {
     "event-source-plus": "^0.1.1",
     "hash-sum": "^2.0.0",

--- a/packages/jerni/scripts/download-binary.js
+++ b/packages/jerni/scripts/download-binary.js
@@ -25,6 +25,8 @@ const osSuffixMap = {
 
 const suffix = `${osSuffixMap[os]}-${currentArch}`;
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 const download = (dest) =>
   new Promise((resolve, reject) => {
     // check if the file exists
@@ -32,8 +34,8 @@ const download = (dest) =>
       return resolve();
     }
 
-    // read the version from package.json using fs and JSON.parse
-    const packageJSON = fs.readFileSync("package.json", "utf-8");
+    // read the version from package.json relative to this script using `fs`
+    const packageJSON = fs.readFileSync(_resolve(__dirname, "../package.json"), "utf-8");
     const { version } = JSON.parse(packageJSON);
 
     const url = `https://github.com/tungv/jerni-3/releases/download/${version}/mycli-${suffix}`;

--- a/packages/jerni/scripts/run-cli.js
+++ b/packages/jerni/scripts/run-cli.js
@@ -12,6 +12,20 @@ const binaryPath = _resolve(__dirname, "../mycli");
 
 await download(binaryPath);
 
+// need to run chmod +x to make the binary executable
+const chmodRun = spawn("chmod", ["+x", binaryPath]);
+
+await new Promise((resolve) => {
+  chmodRun.on("exit", (code) => {
+    if (code !== 0) {
+      console.error("Failed to make the binary executable");
+      process.exit(1);
+    }
+
+    resolve();
+  });
+});
+
 const child = spawn(binaryPath, process.argv.slice(2), {
   stdio: "inherit",
 });


### PR DESCRIPTION
fix(download-binary): read version from the script's package.json instead of the executed folder's package.json

fix(download-binary): auto follow redirect of github

fix(run-cli): run chmod command to allow executable file to run

chore: bump version