### PR TITLE
release v0.4.3

### DIFF
--- a/packages/integrations/tests/CLI/cli-integration.spec.ts
+++ b/packages/integrations/tests/CLI/cli-integration.spec.ts
@@ -25,12 +25,8 @@ it("CLI call should project events correctly", async () => {
     bun run ${jerniCliPath} \
     ${createJourneyPath}`,
     (error, stdout, stderr) => {
-      if (error) {
-        console.error(`exec error: ${error}`);
-        return;
-      }
-      console.log(`stdout: ${stdout}`);
-      console.error(`stderr: ${stderr}`);
+      // console.log(`stdout: ${stdout}`);
+      // console.error(`stderr: ${stderr}`);
     },
   );
 

--- a/packages/integrations/tests/fixtures/BankAccountModel_2.ts
+++ b/packages/integrations/tests/fixtures/BankAccountModel_2.ts
@@ -1,6 +1,7 @@
 import { MongoDBModel } from "@jerni/store-mongodb";
 import type { MongoOps } from "@jerni/store-mongodb/types";
 import mapEvents from "jerni/lib/mapEvents";
+import type { Collection, Document, WithId } from "mongodb";
 
 interface BankAccountDocumentModel {
   id: string;
@@ -19,6 +20,18 @@ declare module "@jerni/jerni-3/types" {
       id: string;
       amount: number;
     };
+  }
+
+  type OptimisticDocumentType<T> = T & {
+    __op: number;
+    __v: number;
+  };
+
+  export interface GetReaderFn {
+    // biome-ignore lint/style/useShorthandFunctionType: need to be interface to override signature
+    <DocumentType extends Document>(model: MongoDBModel<DocumentType>): Promise<
+      Collection<OptimisticDocumentType<WithId<DocumentType>>>
+    >;
   }
 }
 

--- a/packages/jerni/jsr.json
+++ b/packages/jerni/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@jerni/jerni-3",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "exports": {
     ".": "./src/createJourney.ts",
     "./types": "./src/lib/exported_types.ts",

--- a/packages/jerni/package.json
+++ b/packages/jerni/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jerni/jerni-3",
-  "version": "v0.4.2",
+  "version": "v0.4.3",
   "type": "module",
   "main": "src/index.ts",
   "bin": {

--- a/packages/jerni/scripts/convert_jerni_db_to_yaml.js
+++ b/packages/jerni/scripts/convert_jerni_db_to_yaml.js
@@ -1,0 +1,25 @@
+// read file jerni.db
+
+import fs from "node:fs";
+import hash_sum from "hash-sum";
+import yaml from "yaml";
+
+const newFilePath = process.argv[2] || "./events.yaml";
+
+const jerniDbPath = "./jerni.db";
+
+const jerniDb = fs.readFileSync(jerniDbPath, "utf8");
+
+// go line by line, ignore empty lines and lines that start with "#"
+const lines = jerniDb.split("\n").filter((line) => line.trim() && !line.trim().startsWith("#"));
+
+// then parse the lines into an array of objects
+const events = lines.map((line) => JSON.parse(line));
+
+// write to newFilePath
+const content = {
+  checksum: hash_sum(events),
+  events,
+};
+
+fs.writeFileSync(newFilePath, yaml.stringify(content));

--- a/packages/jerni/scripts/run-dev.js
+++ b/packages/jerni/scripts/run-dev.js
@@ -45,6 +45,8 @@ child.on("error", (err) => {
   process.exit(1);
 });
 
-child.on("exit", (code) => {
-  process.exit(code);
+process.on("SIGINT", () => {
+  child.kill("SIGINT");
+
+  process.exit(0);
 });

--- a/packages/jerni/src/lib/exported_types.ts
+++ b/packages/jerni/src/lib/exported_types.ts
@@ -7,13 +7,14 @@ import {
   ToBeCommittedJourneyEvent,
   TypedJourneyCommittedEvent,
 } from "../types/events";
-import { JourneyInstance } from "../types/journey";
+import { GetReaderFn, JourneyInstance } from "../types/journey";
 
 export {
   JourneyCommittedEvent,
   JourneyConfig,
   JourneyEvent,
   JourneyInstance,
+  GetReaderFn,
   TypedJourneyCommittedEvent,
   ToBeCommittedJourneyEvent,
   CommittingEventDefinitions,

--- a/packages/jerni/src/tests/event-db-file.spec.ts
+++ b/packages/jerni/src/tests/event-db-file.spec.ts
@@ -33,12 +33,8 @@ describe("Manipulating event db file", () => {
       `PORT=${port}\
       bun run ${devCliPath} ${initFileName} ${dbFilePath}`,
       (error, stdout, stderr) => {
-        if (error) {
-          console.error(`exec error: ${error}`);
-          return;
-        }
-        console.log(`stdout: ${stdout}`);
-        console.error(`stderr: ${stderr}`);
+        // console.log(`stdout: ${stdout}`);
+        // console.error(`stderr: ${stderr}`);
       },
     );
 
@@ -77,12 +73,8 @@ describe("Manipulating event db file", () => {
         `PORT=${port}\
         bun run ${devCliPath} ${initFileName} ${dbFilePath}`,
         (error, stdout, stderr) => {
-          if (error) {
-            console.error(`exec error: ${error}`);
-            return;
-          }
-          console.log(`stdout: ${stdout}`);
-          console.error(`stderr: ${stderr}`);
+          // console.log(`stdout: ${stdout}`);
+          // console.error(`stderr: ${stderr}`);
         },
       );
 

--- a/packages/jerni/src/types/journey.ts
+++ b/packages/jerni/src/types/journey.ts
@@ -27,5 +27,8 @@ export interface JourneyInstance {
 }
 
 // placeholder for getReader function
-// biome-ignore lint/suspicious/noExplicitAny: because this is a placeholder, the client that uses jerni would override this type
-export type GetReaderFn = (model: any) => Promise<any>;
+export interface GetReaderFn {
+  // biome-ignore lint/style/useShorthandFunctionType: this need to be a interface so that it can be augmented
+  // biome-ignore lint/suspicious/noExplicitAny: because this is a placeholder, the client that uses jerni would override this type
+  (model: any): Promise<any>;
+}


### PR DESCRIPTION
fix: declare GetReaderFn as interface so that it can be overwrote in actual use

chore: overwrite GetReaderFn for integration tests

export get reader fn so that it can be overwrote

chore: comment out logs in tests

chore: also kill child process when parent process is killed

feat: script to convert jerni.db file into yaml file