### PR TITLE
experiment: remove events database

### DIFF
--- a/packages/jerni/jsr.json
+++ b/packages/jerni/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@jerni/jerni-3",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "exports": {
     ".": "./src/createJourney.ts",
     "./types": "./src/lib/exported_types.ts",

--- a/packages/jerni/package.json
+++ b/packages/jerni/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jerni/jerni-3",
-  "version": "v0.8.2",
+  "version": "v0.8.3",
   "type": "module",
   "main": "src/index.ts",
   "bin": {

--- a/packages/jerni/src/asynclocal.ts
+++ b/packages/jerni/src/asynclocal.ts
@@ -1,5 +1,4 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { flow as lodashFlow } from "lodash";
 
 // biome-ignore lint/suspicious/noExplicitAny: any function
 type Fn = (...args: any[]) => any;
@@ -60,8 +59,4 @@ export default function setup<T>(initializer: () => Promise<T>): AsyncLocal<T> {
       storage.disable();
     },
   };
-}
-
-export function flow(...injectors: Inject<unknown>[]): Inject<unknown> {
-  return lodashFlow(...injectors);
 }

--- a/packages/jerni/src/dev-cli/initEventsServerDev.ts
+++ b/packages/jerni/src/dev-cli/initEventsServerDev.ts
@@ -1,5 +1,5 @@
 import type { Server } from "bun";
-import { last, overEvery } from "lodash/fp";
+
 import type { JourneyCommittedEvent } from "../types/events";
 import appendEventsToFile from "./appendEventsToFile";
 import readFile from "./readFile";
@@ -58,7 +58,7 @@ export default async function initEventsServerDev(inputFileName: string, port: n
 
             const latestId = appendEventsToFile(inputFileName, newEvents);
 
-            const latest = last(newEvents);
+            const latest = newEvents.at(-1);
 
             return Response.json(
               {

--- a/packages/jerni/src/dev-cli/initJerniDev.ts
+++ b/packages/jerni/src/dev-cli/initJerniDev.ts
@@ -79,7 +79,7 @@ export default async function initJerniDev(filePath: string | undefined) {
           //    },
           // ]
 
-          for (const storeOutput of outputs.output) {
+          for (const storeOutput of outputs) {
             const collectionNames = Object.keys(storeOutput);
             for (const collectionName of collectionNames) {
               const collectionOutput = storeOutput[collectionName];
@@ -103,7 +103,7 @@ export default async function initJerniDev(filePath: string | undefined) {
           console.log(
             "%s output: %O",
             INF,
-            inspect(outputs.output, { depth: 2, colors: true, compact: 1, breakLength: Number.POSITIVE_INFINITY }),
+            inspect(outputs, { depth: 2, colors: true, compact: 1, breakLength: Number.POSITIVE_INFINITY }),
           );
         }
       } catch (error) {

--- a/packages/jerni/src/getEventStream.ts
+++ b/packages/jerni/src/getEventStream.ts
@@ -12,7 +12,7 @@ const IDLE_TIME = readConfig("IDLE_TIME", "30000", Number);
 const MAX_IDLE_TIME = readConfig("MAX_IDLE_TIME", "900000", Number);
 const BATCH_SIZE = readConfig("BATCH_SIZE", "256", Number);
 const MAX_CHUNK_SIZE = readConfig("MAX_CHUNK_SIZE", "1048576", Number);
-const MAX_CHUNK_COUNT = readConfig("MAX_BATCH_SIZE", "2000", Number);
+const MAX_CHUNK_COUNT = readConfig("MAX_CHUNK_COUNT", "2000", Number);
 
 const RETRY_TIMES = [10, 20, 30, 60, 120, 300, 600, 1200, 1800, 3600];
 
@@ -215,7 +215,6 @@ async function* retrieveJourneyCommittedEvents(
 
       // reset pending size
       pendingSize = r.leftoverData.length;
-      console.log("pendingSize after reset %s", prettyBytes(pendingSize));
 
       const elapsed = Date.now() - timeSinceLastData;
       if (elapsed > idleTime) {

--- a/packages/jerni/src/lib/once.ts
+++ b/packages/jerni/src/lib/once.ts
@@ -1,0 +1,17 @@
+// biome-ignore lint/suspicious/noExplicitAny: any function would be fine
+type AnyFunction = (...args: any[]) => any;
+
+export default function once<T extends AnyFunction>(fn: T): T {
+  let called = false;
+  let result: ReturnType<T>;
+
+  return ((...args: Parameters<T>) => {
+    if (called) {
+      return result;
+    }
+
+    called = true;
+    result = fn(...args);
+    return result;
+  }) as T;
+}


### PR DESCRIPTION
we will add it back later but I'm not sure we will keep the same flow as of now.

I think sqlite as a temporary layer to persist event data that's not processed yet. It should not be the source of truth (replica) of an events-server.