### PR TITLE
fix: do not debounce ping fn

### DIFF
--- a/packages/jerni/jsr.json
+++ b/packages/jerni/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@jerni/jerni-3",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "exports": {
     ".": "./src/createJourney.ts",
     "./types": "./src/lib/exported_types.ts",

--- a/packages/jerni/package.json
+++ b/packages/jerni/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jerni/jerni-3",
-  "version": "v0.9.7",
+  "version": "v0.9.8",
   "type": "module",
   "main": "src/index.ts",
   "bin": {

--- a/packages/jerni/src/begin.ts
+++ b/packages/jerni/src/begin.ts
@@ -1,6 +1,5 @@
 import { gcAndSweep, memoryUsage } from "bun:jsc";
 import { mkdir } from "node:fs/promises";
-import { debounce } from "lodash/fp";
 import prettyBytes from "pretty-bytes";
 import prettyMilliseconds from "pretty-ms";
 import UnrecoverableError from "./UnrecoverableError";

--- a/packages/jerni/src/begin.ts
+++ b/packages/jerni/src/begin.ts
@@ -96,9 +96,9 @@ export default async function* begin(journey: JourneyInstance, signal: AbortSign
   let latestHandled = clientLatest;
 
   const newEventNotifier = new EventTarget();
-  const ping = debounce(300, function ping() {
+  const ping = function ping() {
     newEventNotifier.dispatchEvent(new Event("latest"));
-  });
+  };
 
   (async () => {
     const eventStream = await getEventStreamFromUrl(clientLatest.toString(), subscriptionUrl, db, signal, logger);

--- a/packages/jerni/src/lib/commit.ts
+++ b/packages/jerni/src/lib/commit.ts
@@ -20,6 +20,8 @@ export default async function commitToServer<T extends keyof CommittingEventDefi
 ): Promise<TypedJourneyCommittedEvent<T>> {
   logger.debug("committing...");
   const commitUrl = new URL("commit", url);
+  commitUrl.username = "";
+  commitUrl.password = "";
 
   const localId = nanoid();
   const event = {
@@ -52,6 +54,7 @@ export default async function commitToServer<T extends keyof CommittingEventDefi
     headers: {
       "content-type": "application/json",
       "x-request-id": localId,
+      authorization: `Basic ${btoa(`${url.username}:${url.password}`)}`,
     },
     body: JSON.stringify(event),
   });


### PR DESCRIPTION
when it's debounced, new incoming events have to wait 300ms before it's executed

Signed-off-by: Tung Vu <me@tungv.com>