### PR TITLE
Binary events file

### DIFF
--- a/packages/integrations/tests/CLI/jerni-dev.spec.ts
+++ b/packages/integrations/tests/CLI/jerni-dev.spec.ts
@@ -171,15 +171,17 @@ describe("Jerni Dev Integration", () => {
     const port = Math.floor(Math.random() * 10000) + 10000;
     const dbFileName = `./test-events-db-${nanoid()}.yml`;
     const mongodbName = `jerni_integration_test_${nanoid()}`;
+    const sqliteFileName = `./test-events-db-${nanoid()}.sqlite`;
 
     const devCliPath = path.resolve(__dirname, "../../../jerni/src/dev-cli/index.ts");
     const initFileName = path.resolve(__dirname, "./makeTestJourneyCli.ts");
     const dbFilePath = path.resolve(__dirname, dbFileName);
+    const sqliteFilePath = path.resolve(__dirname, sqliteFileName);
 
     const childProcess = exec(
       `PORT=${port}\
         MONGODB_DBNAME=${mongodbName}\
-        bun run ${devCliPath} ${initFileName} ${dbFilePath}`,
+        bun run ${devCliPath} ${initFileName} ${dbFilePath} ${sqliteFilePath}`,
       (error, stdout, stderr) => {
         // console.log(`stdout: ${stdout}`);
         // console.error(`stderr: ${stderr}`);

--- a/packages/integrations/tests/CLI/jerni-dev.spec.ts
+++ b/packages/integrations/tests/CLI/jerni-dev.spec.ts
@@ -77,15 +77,17 @@ describe("Jerni Dev Integration", () => {
     const port = Math.floor(Math.random() * 10000) + 10000;
     const dbFileName = `./test-events-db-${nanoid()}.yml`;
     const mongodbName = `jerni_integration_test_${nanoid()}`;
+    const sqliteFileName = `./test-events-db-${nanoid()}.sqlite`;
 
     const devCliPath = path.resolve(__dirname, "../../../jerni/src/dev-cli/index.ts");
     const initFileName = path.resolve(__dirname, "./makeTestJourneyCli.ts");
     const dbFilePath = path.resolve(__dirname, dbFileName);
+    const sqliteFilePath = path.resolve(__dirname, sqliteFileName);
 
     const childProcess = exec(
       `PORT=${port}\
         MONGODB_DBNAME=${mongodbName}\
-        bun run ${devCliPath} ${initFileName} ${dbFilePath}`,
+        bun run ${devCliPath} ${initFileName} ${dbFilePath} ${sqliteFilePath}`,
       (error, stdout, stderr) => {
         // console.log("stdout: ", stdout);
         // console.error("stderr: ", stderr);
@@ -118,7 +120,6 @@ describe("Jerni Dev Integration", () => {
     });
 
     await journey.waitFor(event2);
-    // await setTimeout(1000);
 
     // check balance to be 100
     const BankAccounts = await journey.getReader(BankAccountModel_2);

--- a/packages/integrations/tests/CLI/jerni-dev.spec.ts
+++ b/packages/integrations/tests/CLI/jerni-dev.spec.ts
@@ -71,6 +71,33 @@ describe("Jerni Dev Integration", () => {
       balance: 0,
     });
 
+    const event2 = await journey.append<"NEW_ACCOUNT_REGISTERED">({
+      type: "NEW_ACCOUNT_REGISTERED",
+      payload: {
+        id: "1234",
+        name: "test",
+      },
+    });
+
+    await setTimeout(1000);
+
+    childProcess.kill();
+
+    await journey.waitFor(event2);
+
+    const bankAccount2 = await BankAccounts.findOne({
+      id: "1234",
+    });
+
+    expect(bankAccount2).toEqual({
+      __op: 0,
+      __v: 2,
+      _id: expect.anything(),
+      id: "1234",
+      name: "test",
+      balance: 0,
+    });
+
     childProcess.kill();
   });
 

--- a/packages/integrations/tests/CLI/jerni-dev.spec.ts
+++ b/packages/integrations/tests/CLI/jerni-dev.spec.ts
@@ -19,15 +19,17 @@ describe("Jerni Dev Integration", () => {
     const port = Math.floor(Math.random() * 10000) + 10000;
     const dbFileName = `./test-events-db-${nanoid()}.yml`;
     const mongodbName = `jerni_integration_test_${nanoid()}`;
+    const sqliteFileName = `./test-events-db-${nanoid()}.sqlite`;
 
     const devCliPath = path.resolve(__dirname, "../../../jerni/src/dev-cli/index.ts");
     const initFileName = path.resolve(__dirname, "./makeTestJourneyCli.ts");
     const dbFilePath = path.resolve(__dirname, dbFileName);
+    const sqliteFilePath = path.resolve(__dirname, sqliteFileName);
 
     const childProcess = exec(
       `PORT=${port}\
         MONGODB_DBNAME=${mongodbName}\
-        bun run ${devCliPath} ${initFileName} ${dbFilePath}`,
+        bun run ${devCliPath} ${initFileName} ${dbFilePath} ${sqliteFilePath}`,
       (error, stdout, stderr) => {
         // console.log(`stdout: ${stdout}`);
         // console.error(`stderr: ${stderr}`);

--- a/packages/integrations/tests/CLI/jerni-dev.spec.ts
+++ b/packages/integrations/tests/CLI/jerni-dev.spec.ts
@@ -219,12 +219,6 @@ describe("Jerni Dev Integration", () => {
 
     await setTimeout(1000);
 
-    // write r and press enter to child process
-    if (!childProcess.stdin) {
-      throw new Error("child process has no stdin");
-    }
-    childProcess.stdin.write("r\n");
-
     process.env.EVENTS_SERVER = `http://localhost:${port}`;
     const mongoConfig = {
       url: "mongodb://localhost:27017",
@@ -249,7 +243,6 @@ describe("Jerni Dev Integration", () => {
     });
 
     await journey.waitFor(event2);
-    // await setTimeout(1000);
 
     // check balance to be 100
     const BankAccounts = await journey.getReader(BankAccountModel_2);

--- a/packages/jerni/src/begin.ts
+++ b/packages/jerni/src/begin.ts
@@ -17,7 +17,7 @@ import type { JourneyInstance } from "./types/journey";
 const defaultLogger = console;
 
 interface RunConfig {
-  dbFolder: string;
+  dbFolder?: string;
 }
 
 export default async function* begin(journey: JourneyInstance, signal: AbortSignal, runConfig?: RunConfig) {

--- a/packages/jerni/src/dev-cli/appendEventsToFile.ts
+++ b/packages/jerni/src/dev-cli/appendEventsToFile.ts
@@ -1,11 +1,12 @@
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import hash_sum from "hash-sum";
 import yaml from "yaml";
 import type { JourneyCommittedEvent } from "../types/events";
 import type { SavedData } from "./readFile";
 
-export default function appendEventsToFile(filePath: string, events: JourneyCommittedEvent[]) {
-  const fileContent = fs.readFileSync(filePath, "utf8");
+export default async function appendEventsToFileAsync(filePath: string, events: JourneyCommittedEvent[]) {
+  const fileContent = await fs.readFile(filePath, { encoding: "utf8" });
+
   const parsedContent = yaml.parse(fileContent) as SavedData;
 
   parsedContent.events.push(...events);
@@ -15,7 +16,7 @@ export default function appendEventsToFile(filePath: string, events: JourneyComm
 
   const stringifiedContent = yaml.stringify(parsedContent);
 
-  fs.writeFileSync(filePath, stringifiedContent);
+  await fs.writeFile(filePath, stringifiedContent);
 
   return parsedContent.events.length;
 }

--- a/packages/jerni/src/dev-cli/commitEvent.ts
+++ b/packages/jerni/src/dev-cli/commitEvent.ts
@@ -1,0 +1,28 @@
+import sqlite from "bun:sqlite";
+import type { JourneyCommittedEvent } from "../types/events";
+import appendEventsToFile from "./appendEventsToFile";
+
+export default function commitEvent(sqliteFilePath: string, textFilePath: string, events: JourneyCommittedEvent[]) {
+  writeEventToSqlite(sqliteFilePath, events);
+  const lastId = appendEventsToFile(textFilePath, events);
+
+  return lastId;
+}
+
+function writeEventToSqlite(filePath: string, events: JourneyCommittedEvent[]) {
+  const db = sqlite.open(filePath);
+
+  try {
+    const query = db.prepare("INSERT INTO events (type, payload, meta) VALUES ($type, $payload, $meta)");
+
+    for (const event of events) {
+      query.run({
+        $type: event.type,
+        $payload: JSON.stringify(event.payload),
+        $meta: JSON.stringify(event.meta),
+      });
+    }
+  } finally {
+    db.close();
+  }
+}

--- a/packages/jerni/src/dev-cli/commitEvent.ts
+++ b/packages/jerni/src/dev-cli/commitEvent.ts
@@ -21,7 +21,7 @@ function writeEventToSqlite(filePath: string, events: JourneyCommittedEvent[]) {
       query.run({
         $type: event.type,
         $payload: JSON.stringify(event.payload),
-        $meta: JSON.stringify(event.meta),
+        $meta: JSON.stringify(event.meta ?? {}),
       });
     }
 

--- a/packages/jerni/src/dev-cli/ensureFileExists.ts
+++ b/packages/jerni/src/dev-cli/ensureFileExists.ts
@@ -1,0 +1,14 @@
+import fs from "node:fs";
+import yaml from "yaml";
+
+export default function ensureFileExists(filePath: string) {
+  if (!fs.existsSync(filePath)) {
+    const content = {
+      checksum: "",
+      events: [],
+    };
+
+    const stringifiedContent = yaml.stringify(content);
+    fs.writeFileSync(filePath, stringifiedContent);
+  }
+}

--- a/packages/jerni/src/dev-cli/ensureSqliteTable.ts
+++ b/packages/jerni/src/dev-cli/ensureSqliteTable.ts
@@ -1,0 +1,20 @@
+import sqlite from "bun:sqlite";
+
+export default function ensureSqliteTable(filePath: string) {
+  const db = sqlite.open(filePath);
+
+  try {
+    db.query(
+      `
+CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY,
+  payload TEXT NOT NULL,
+  meta TEXT NOT NULL,
+  type TEXT NOT NULL
+  );
+  `,
+    ).get();
+  } finally {
+    db.close();
+  }
+}

--- a/packages/jerni/src/dev-cli/index.ts
+++ b/packages/jerni/src/dev-cli/index.ts
@@ -12,11 +12,13 @@ import { syncWithBinary } from "./syncWithBinary";
 
 console.log("%s jerni dev is starting...", INF);
 
+// TODO: use `minimist` or `sade` here to handle arguments better
 const [_bun, _script, initFileName, textDbFile, sqliteDbFile] = process.argv;
 
 await guardErrors(
   async () => {
-    const port = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 5000;
+    // TODO: move reading port to args instead of env, or just randomize it
+    const port = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 5001;
 
     const textFilePath = textDbFile ? textDbFile : "./events.yaml";
     const sqliteFilePath = sqliteDbFile ? sqliteDbFile : "./events.sqlite";
@@ -66,14 +68,14 @@ await guardErrors(
           return;
         }
 
-          console.log("%s checksum mismatch, clean starting jerni dev…", INF);
+        console.log("%s checksum mismatch, clean starting jerni dev…", INF);
         await stopJourney();
 
-          syncWithBinary(textFilePath, sqliteFilePath);
+        syncWithBinary(textFilePath, sqliteFilePath);
 
-          startJourney({
-            cleanStart: true,
-          });
+        startJourney({
+          cleanStart: true,
+        });
       }, 300),
     );
 

--- a/packages/jerni/src/dev-cli/index.ts
+++ b/packages/jerni/src/dev-cli/index.ts
@@ -85,10 +85,12 @@ await guardErrors(
       const input = data.toString().trim();
 
       if (input === "r") {
-        console.log("%s clean starting jerni dev...", INF);
+        console.log("%s forced restart command received, clean starting jerni dev...", INF);
 
         await stopEventsServer();
         await stopJourney();
+
+        syncWithBinary(dbFilePath, sqliteFilePath);
 
         startEventsServer();
         startJourney({

--- a/packages/jerni/src/dev-cli/index.ts
+++ b/packages/jerni/src/dev-cli/index.ts
@@ -57,7 +57,6 @@ await guardErrors(
       debounce(async () => {
         console.log("%s file changed, restarting jerni dev...", INF);
 
-        await stopEventsServer();
         await stopJourney();
 
         const { fileChecksum, realChecksum } = readFile(dbFilePath);
@@ -67,7 +66,6 @@ await guardErrors(
 
           syncWithBinary(dbFilePath, sqliteFilePath);
 
-          startEventsServer();
           startJourney({
             cleanStart: true,
           });
@@ -75,7 +73,6 @@ await guardErrors(
           return;
         }
 
-        startEventsServer();
         startJourney();
       }, 300),
     );
@@ -87,12 +84,10 @@ await guardErrors(
       if (input === "r") {
         console.log("%s forced restart command received, clean starting jerni dev...", INF);
 
-        await stopEventsServer();
         await stopJourney();
 
         syncWithBinary(dbFilePath, sqliteFilePath);
 
-        startEventsServer();
         startJourney({
           cleanStart: true,
         });

--- a/packages/jerni/src/dev-cli/index.ts
+++ b/packages/jerni/src/dev-cli/index.ts
@@ -60,25 +60,20 @@ await guardErrors(
     fs.watch(
       textFilePath,
       debounce(async () => {
-        console.log("%s file changed, restarting jerni dev...", INF);
-
-        await stopJourney();
-
         const { fileChecksum, realChecksum } = readFile(textFilePath);
 
-        if (fileChecksum !== realChecksum) {
+        if (fileChecksum === realChecksum) {
+          return;
+        }
+
           console.log("%s checksum mismatch, clean starting jerni dev…", INF);
+        await stopJourney();
 
           syncWithBinary(textFilePath, sqliteFilePath);
 
           startJourney({
             cleanStart: true,
           });
-
-          return;
-        }
-
-        startJourney();
       }, 300),
     );
 

--- a/packages/jerni/src/dev-cli/index.ts
+++ b/packages/jerni/src/dev-cli/index.ts
@@ -12,19 +12,24 @@ import rewriteChecksum from "./rewriteChecksum";
 
 console.log("%s jerni dev is starting...", INF);
 
-const [_bun, _script, initFileName, dbFileName] = process.argv;
+const [_bun, _script, initFileName, textDbFile, sqliteDbFile] = process.argv;
 
 await guardErrors(
   async () => {
     const port = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 5000;
 
-    const dbFilePath = dbFileName ? dbFileName : "./events.yaml";
+    const dbFilePath = textDbFile ? textDbFile : "./events.yaml";
+    const sqliteFilePath = sqliteDbFile ? sqliteDbFile : "./events.sqlite";
 
     process.env.EVENTS_SERVER = `http://localhost:${port}`;
 
     const { start: startJourney, stop: stopJourney } = await initJerniDev(initFileName);
 
-    const { start: startEventsServer, stop: stopEventsServer } = await initEventsServerDev(dbFilePath, port);
+    const { start: startEventsServer, stop: stopEventsServer } = await initEventsServerDev(
+      dbFilePath,
+      sqliteFilePath,
+      port,
+    );
 
     // call server.stop when process is killed
     process.on("SIGINT", () => {

--- a/packages/jerni/src/dev-cli/index.ts
+++ b/packages/jerni/src/dev-cli/index.ts
@@ -40,8 +40,13 @@ await guardErrors(
 
     // onError, stop journey and server
     process.on("unhandledRejection", (error) => {
-      console.error("%s unhandledRejection", INF);
-      console.error(error);
+      // if abort error, ignore
+      if (error instanceof Error && error.name === "AbortError") {
+        return;
+      }
+
+      console.log("%s unhandledRejection", INF);
+      console.log(error);
 
       stopJourney();
       stopEventsServer();

--- a/packages/jerni/src/dev-cli/index.ts
+++ b/packages/jerni/src/dev-cli/index.ts
@@ -8,7 +8,7 @@ import guardErrors from "../guardErrors";
 import initEventsServerDev from "./initEventsServerDev";
 import initJerniDev from "./initJerniDev";
 import readFile from "./readFile";
-import rewriteChecksum from "./rewriteChecksum";
+import { syncWithBinary } from "./syncWithBinary";
 
 console.log("%s jerni dev is starting...", INF);
 
@@ -65,7 +65,7 @@ await guardErrors(
         if (fileChecksum !== realChecksum) {
           console.log("%s checksum mismatch, clean starting jerni dev…", INF);
 
-          rewriteChecksum(dbFilePath);
+          syncWithBinary(dbFilePath, sqliteFilePath);
 
           startEventsServer();
           startJourney({

--- a/packages/jerni/src/dev-cli/index.ts
+++ b/packages/jerni/src/dev-cli/index.ts
@@ -8,7 +8,7 @@ import guardErrors from "../guardErrors";
 import initEventsServerDev from "./initEventsServerDev";
 import initJerniDev from "./initJerniDev";
 import readFile from "./readFile";
-import { syncWithBinary } from "./syncWithBinary";
+import syncWithBinary from "./syncWithBinary";
 
 console.log("%s jerni dev is starting...", INF);
 

--- a/packages/jerni/src/dev-cli/index.ts
+++ b/packages/jerni/src/dev-cli/index.ts
@@ -18,7 +18,7 @@ await guardErrors(
   async () => {
     const port = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 5000;
 
-    const dbFilePath = textDbFile ? textDbFile : "./events.yaml";
+    const textFilePath = textDbFile ? textDbFile : "./events.yaml";
     const sqliteFilePath = sqliteDbFile ? sqliteDbFile : "./events.sqlite";
 
     process.env.EVENTS_SERVER = `http://localhost:${port}`;
@@ -26,7 +26,7 @@ await guardErrors(
     const { start: startJourney, stop: stopJourney } = await initJerniDev(initFileName);
 
     const { start: startEventsServer, stop: stopEventsServer } = await initEventsServerDev(
-      dbFilePath,
+      textFilePath,
       sqliteFilePath,
       port,
     );
@@ -53,18 +53,18 @@ await guardErrors(
 
     // listen for file changes and restart journey
     fs.watch(
-      dbFilePath,
+      textFilePath,
       debounce(async () => {
         console.log("%s file changed, restarting jerni dev...", INF);
 
         await stopJourney();
 
-        const { fileChecksum, realChecksum } = readFile(dbFilePath);
+        const { fileChecksum, realChecksum } = readFile(textFilePath);
 
         if (fileChecksum !== realChecksum) {
           console.log("%s checksum mismatch, clean starting jerni dev…", INF);
 
-          syncWithBinary(dbFilePath, sqliteFilePath);
+          syncWithBinary(textFilePath, sqliteFilePath);
 
           startJourney({
             cleanStart: true,
@@ -86,7 +86,7 @@ await guardErrors(
 
         await stopJourney();
 
-        syncWithBinary(dbFilePath, sqliteFilePath);
+        syncWithBinary(textFilePath, sqliteFilePath);
 
         startJourney({
           cleanStart: true,

--- a/packages/jerni/src/dev-cli/initEventsServerDev.ts
+++ b/packages/jerni/src/dev-cli/initEventsServerDev.ts
@@ -23,6 +23,8 @@ export default async function initEventsServerDev(textFileName: string, sqliteFi
 
   return {
     start: async () => {
+      ensureFileExists(textFileName);
+
       ensureSqliteTable(sqliteFileName);
 
       const eventsInDb = getEventsFromSqlite(sqliteFileName);
@@ -79,7 +81,8 @@ export default async function initEventsServerDev(textFileName: string, sqliteFi
 
             const newEvents = Array.isArray(event) ? event : [event];
 
-            const latestId = appendEventsToFile(inputFileName, newEvents);
+            // const latestId = appendEventsToFile(textFileName, newEvents);
+            const latestId = commitEvent(sqliteFileName, textFileName, newEvents);
 
             const latest = newEvents.at(-1);
 

--- a/packages/jerni/src/dev-cli/initJerniDev.ts
+++ b/packages/jerni/src/dev-cli/initJerniDev.ts
@@ -1,5 +1,4 @@
 import { inspect } from "node:util";
-import { isUndefined, omitBy } from "lodash/fp";
 import { bold, green, red } from "picocolors";
 import InvalidInputError from "../InvalidInputError";
 import { assertFilePath } from "../assertFilePath";
@@ -68,38 +67,7 @@ export default async function initJerniDev(filePath: string | undefined) {
         );
 
         for await (const outputs of begin(journey, ctrl.signal)) {
-          // remove all fields that are 0
-          // outputs has the following shape
-          // [
-          //   {
-          //    collection_name: {
-          //      added: 1,
-          //      updated: 0,
-          //      deleted: 0,
-          //    },
-          // ]
-
-          for (const storeOutput of outputs) {
-            const collectionNames = Object.keys(storeOutput);
-            for (const collectionName of collectionNames) {
-              const collectionOutput = storeOutput[collectionName];
-
-              // remove all fields that are 0, delete the field cause biome to warn about low performance
-              if (collectionOutput.added === 0) {
-                collectionOutput.added = undefined;
-              }
-              if (collectionOutput.updated === 0) {
-                collectionOutput.updated = undefined;
-              }
-              if (collectionOutput.deleted === 0) {
-                collectionOutput.deleted = undefined;
-              }
-
-              // remove all fields that are undefined
-              storeOutput[collectionName] = omitBy(isUndefined)(collectionOutput);
-            }
-          }
-
+          // Any store can be used here, we don't have the exact output contract
           console.log(
             "%s output: %O",
             INF,

--- a/packages/jerni/src/dev-cli/initJerniDev.ts
+++ b/packages/jerni/src/dev-cli/initJerniDev.ts
@@ -28,7 +28,7 @@ export default async function initJerniDev(filePath: string | undefined) {
     );
   }
 
-  let ctrl: AbortController;
+  let ctrl: AbortController | undefined;
   let started = false;
 
   return {
@@ -87,6 +87,8 @@ export default async function initJerniDev(filePath: string | undefined) {
       }
 
       ctrl.abort();
+
+      ctrl = undefined;
     },
   };
 }

--- a/packages/jerni/src/dev-cli/readFile.ts
+++ b/packages/jerni/src/dev-cli/readFile.ts
@@ -10,20 +10,6 @@ export type SavedData = {
 };
 
 export default function readFile(filePath: string) {
-  // check if file exists
-  if (!fs.existsSync(filePath)) {
-    // if not, create a new file
-    // the first line is checksum: $hash of the content
-
-    const content = {
-      checksum: "",
-      events: [],
-    };
-
-    const stringifiedContent = yaml.stringify(content);
-    fs.writeFileSync(filePath, stringifiedContent);
-  }
-
   const fileContent = fs.readFileSync(filePath, "utf8");
   const parsedContent = yaml.parse(fileContent) as SavedData;
 

--- a/packages/jerni/src/dev-cli/syncWithBinary.ts
+++ b/packages/jerni/src/dev-cli/syncWithBinary.ts
@@ -3,7 +3,10 @@ import ensureFileExists from "./ensureFileExists";
 import readFile from "./readFile";
 import rewriteChecksum from "./rewriteChecksum";
 
-export function syncWithBinary(textFilePath: string, sqliteFilePath: string) {
+/**
+ * This function changes the content of the binary file.
+ */
+export default function syncWithBinary(textFilePath: string, sqliteFilePath: string) {
   ensureFileExists(textFilePath);
   ensureFileExists(sqliteFilePath);
 

--- a/packages/jerni/src/dev-cli/syncWithBinary.ts
+++ b/packages/jerni/src/dev-cli/syncWithBinary.ts
@@ -1,0 +1,25 @@
+import sqlite from "bun:sqlite";
+import ensureFileExists from "./ensureFileExists";
+import readFile from "./readFile";
+import rewriteChecksum from "./rewriteChecksum";
+
+export function syncWithBinary(textFilePath: string, sqliteFilePath: string) {
+  ensureFileExists(textFilePath);
+  ensureFileExists(sqliteFilePath);
+
+  rewriteChecksum(textFilePath);
+
+  const { events } = readFile(textFilePath);
+
+  // delete all events in sqlite
+  // and write all events from text file to sqlite
+  const db = sqlite.open(sqliteFilePath);
+
+  db.exec("DELETE FROM events");
+
+  const query = db.prepare("INSERT INTO events ( type, payload, meta) VALUES (?, ?, ?)");
+
+  for (const event of events) {
+    query.run(event.type, JSON.stringify(event.payload), JSON.stringify(event.meta));
+  }
+}

--- a/packages/jerni/src/dev-cli/syncWithBinary.ts
+++ b/packages/jerni/src/dev-cli/syncWithBinary.ts
@@ -15,11 +15,12 @@ export function syncWithBinary(textFilePath: string, sqliteFilePath: string) {
   // and write all events from text file to sqlite
   const db = sqlite.open(sqliteFilePath);
 
-  db.exec("DELETE FROM events");
+  // delete all rows of table events
+  db.prepare("DELETE FROM events").run();
 
-  const query = db.prepare("INSERT INTO events ( type, payload, meta) VALUES (?, ?, ?)");
+  const query = db.prepare("INSERT INTO events (type, payload, meta) VALUES (?, ?, ?)");
 
   for (const event of events) {
-    query.run(event.type, JSON.stringify(event.payload), JSON.stringify(event.meta));
+    query.run(event.type, JSON.stringify(event.payload), JSON.stringify(event.meta ?? {}));
   }
 }


### PR DESCRIPTION
## Done
- [x] create a new sqlite file to read/write events faster
- [x] eventually update new organic events to text readable file
- [x] on clean start(r pressed, or no organic changed) sync data from text file to sqlite file
- [x] Clean up and add some todo suggestions when implementing the new jerni dev

## Try it for yourself
Run this script command in the root of the jerni-3 repo
```bash
# run-jerni-dev.sh
export MONGODB_DBNAME="local_ops"
export MONGODB_URL="mongodb://127.0.0.1:27017"

mongosh --eval "db.getMongo().getDBNames().forEach(function(i){if(i!='admin' && i!='local' && i!='config') db.getSiblingDB(i).dropDatabase()})"

bun run ./packages/jerni/src/dev-cli/index.ts /Users/quanvo/Documents/git-repos/bodidata/bodidata-ops/src/journey/index.ts /Users/quanvo/Documents/git-repos/bodidata/bodidata-ops/events.yaml /Users/quanvo/Documents/git-repos/bodidata/bodidata-ops/events.sqlite
```

### Notes
- Change the file's path to ops to the actual file path on your machine
- To generate the events.yaml file, run the following command in ops repo:
```bash
node node_modules/@jerni/jerni-3/scripts/convert_jerni_db_to_yaml.js
```